### PR TITLE
feat(1041): Add repo package for parsing and command execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Screwdriver
+
+Have a look at our guidelines, as well as pointers on where to start making changes, in our official [documentation](https://docs.screwdriver.cd/about/contributing/pull-requests).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2018 Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # sd-repo
+[![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url]
+
+> Tool for executing the [Repo](https://source.android.com/setup/develop/repo) workflow for `getCheckoutCommand` in [screwdriver-scm-github](https://github.com/screwdriver-cd/scm-github/blob/master/index.js#L272)
+
+## Usage
+
+```bash
+sd-repo -manifestUrl=git@github.com:org/manifestRepo.git/default.xml -sourceRepo=org/appRepo
+```
+
+## Testing
+
+```bash
+go test ./...
+```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver.svg
+[issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
+[status-image]: https://cd.screwdriver.cd/pipelines/796/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/796

--- a/data/manifest.xml
+++ b/data/manifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remote name="origin" fetch="ssh://git@github.com/" />
+  <default revision="master" remote="origin" />
+
+  <project path="primary"
+           name="filbird/v4-repo-test.git" remote="origin" />
+
+  <project path="dependencies/timeout"
+           name="filbird/v4-timeout-test.git" remote="origin" />
+
+  <project path="dependencies/cron"
+           name="filbird/v4-cron-test.git" remote="origin" />
+
+</manifest>

--- a/git/git.go
+++ b/git/git.go
@@ -14,10 +14,12 @@ type GitUrl struct {
 	Branch string
 }
 
+// GetCloneInfo returns the url and branch of the GitUrl
 func (git *GitUrl) GetCloneInfo() (url, branch string) {
 	return fmt.Sprintf("git@%+s:%+s/%+s.git", git.Host, git.Org, git.Repo), git.Branch
 }
 
+// New validates the gitUrlStr and returns a new GitUrl object
 func New(gitUrlStr string) (*GitUrl, error) {
 	// This would match something like git@github.com:org/repo.git/path#branch
 	// path and branch are optional. If not given, default values are "" and "master"
@@ -25,7 +27,7 @@ func New(gitUrlStr string) (*GitUrl, error) {
 	parseResult := gitUrlRegex.FindStringSubmatch(gitUrlStr)
 
 	if parseResult == nil {
-		return nil, fmt.Errorf("Error: not a valid git url %+s", gitUrlStr)
+		return nil, fmt.Errorf("Not a valid git url %+s", gitUrlStr)
 	}
 
 	gitUrl := GitUrl{

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -39,25 +39,25 @@ func TestParseGitUrlError(t *testing.T) {
 	var gitUrlBad1, err1 = New("git@github.com::screwdriver-cd/sd-repo.git/model/giturl_test.go#test")
 	assert.Nil(t, gitUrlBad1)
 	if assert.Error(t, err1, "should return error on invalid git config") {
-		assert.Equal(t, "Error: not a valid git url git@github.com::screwdriver-cd/sd-repo.git/model/giturl_test.go#test", err1.Error())
+		assert.Equal(t, "Not a valid git url git@github.com::screwdriver-cd/sd-repo.git/model/giturl_test.go#test", err1.Error())
 	}
 
 	var gitUrlBad2, err2 = New("git@github.com:sd-repo.git/model/giturl_test.go#test")
 	assert.Nil(t, gitUrlBad2)
 	if assert.Error(t, err2, "should return error on invalid git config") {
-		assert.Equal(t, "Error: not a valid git url git@github.com:sd-repo.git/model/giturl_test.go#test", err2.Error())
+		assert.Equal(t, "Not a valid git url git@github.com:sd-repo.git/model/giturl_test.go#test", err2.Error())
 	}
 
 	var gitUrlBad3, err3 = New("git@github.com:a/b/model/giturl_test.git")
 	assert.Nil(t, gitUrlBad3)
 	if assert.Error(t, err3, "should return error on invalid git config") {
-		assert.Equal(t, "Error: not a valid git url git@github.com:a/b/model/giturl_test.git", err3.Error())
+		assert.Equal(t, "Not a valid git url git@github.com:a/b/model/giturl_test.git", err3.Error())
 	}
 
 	var gitUrlBad4, err4 = New("github.com:a/b.git#branch")
 	assert.Nil(t, gitUrlBad4)
 	if assert.Error(t, err4, "should return error on invalid git config") {
-		assert.Equal(t, "Error: not a valid git url github.com:a/b.git#branch", err4.Error())
+		assert.Equal(t, "Not a valid git url github.com:a/b.git#branch", err4.Error())
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,79 @@
+package main
+
+import(
+  "fmt"
+  "flag"
+  "os"
+  "io/ioutil"
+
+  "github.com/screwdriver-cd/sd-repo/git"
+  "github.com/screwdriver-cd/sd-repo/repo"
+)
+
+// sourcePathFile is the file in which the checked out source path
+// will be written to
+const sourcePathFile = "sourcePath"
+
+var (
+    newGitUrl = git.New
+    repoInit = repo.Init
+    repoSync = repo.Sync
+    parseManifestFile = repo.ParseManifestFile
+    findProject = repo.FindProject
+    writeFile = ioutil.WriteFile
+)
+
+// run executes the Repo workflow for 'getCheckoutCommand' in screwdriver-scm-github
+// It initializes the Repo repository via `repo init`
+// After parsing and validating the manifest file, it checks out dependencies via `repo sync`
+// Lastly, it outputs the source repository's path to sourcePathFile
+func run(manifestUrl, sourceRepo string) error {
+    // Validate the manifestUrl
+    gitUrl, err := newGitUrl(manifestUrl)
+    if err != nil {
+        return fmt.Errorf("Error validating manifest URL: %v\n", err)
+    }
+    checkoutUrl, branch := gitUrl.GetCloneInfo()
+
+    // Initialize Repo repository
+    err = repoInit(checkoutUrl,branch,gitUrl.Path)
+    if err != nil {
+        return fmt.Errorf("Error executing 'repo init': %v\n", err)
+    }
+
+    manifest, err := parseManifestFile()
+    if err != nil {
+        return fmt.Errorf("Error parsing manifest file: %v\n", err)
+    }
+
+    project := findProject(manifest, sourceRepo)
+    if project == nil {
+        return fmt.Errorf("Error: Source repo, %v, is not listed in the manifest file, %v\n", sourceRepo, gitUrl.Path)
+    }
+
+    // Checkout dependencies
+    err = repoSync()
+    if err != nil {
+        return fmt.Errorf("Error executing 'repo sync': %v\n", err)
+    }
+
+    fmt.Printf("Writing source repository path to %v\n", sourcePathFile)
+    err = writeFile(sourcePathFile, []byte(project.Path), 0444)
+    if err != nil {
+        return fmt.Errorf("Error writing to %v: %v\n", sourcePathFile, err)
+    }
+
+    return nil
+}
+
+func main() {
+    manifestUrl := flag.String("manifestUrl", "", "URL of the repository containing the repo manifest file")
+    sourceRepo := flag.String("sourceRepo", "", "Source repository")
+    flag.Parse()
+
+    err := run(*manifestUrl, *sourceRepo);
+    if err != nil {
+        fmt.Printf("%v", err)
+        os.Exit(1)
+    }
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import(
+    "fmt"
+    "os"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/screwdriver-cd/sd-repo/git"
+    "github.com/screwdriver-cd/sd-repo/repo"
+)
+
+const (
+    testManifestUrl = "git@github.com:filbird/v4-repo-test.git/default.xml"
+    testSourceRepo = "filbird/v4-repo-test.git"
+)
+
+var (
+    testProject = repo.Project { Path: "primary", Name: "filbird/v4-repo-test.git" }
+    testManifest = repo.Manifest { Projects: []repo.Project { testProject } }
+    testGitUrl = git.GitUrl {
+        Host:   "github.com",
+        Org:    "filbird",
+        Repo:   "v4-repo-test",
+        Path:   "default.xml",
+        Branch: "master",
+    }
+);
+
+func TestMain(m *testing.M) {
+    // Mcok out functions
+    newGitUrl  = func(testGitUrlStr string) (*git.GitUrl, error) {return &testGitUrl, nil }
+    repoInit = func(checkoutUrl, branch, path string) error { return nil }
+    parseManifestFile = func() (*repo.Manifest, error) { return &testManifest, nil }
+    repoSync = func() error { return nil }
+    parseManifestFile = func() (*repo.Manifest, error) { return &testManifest, nil }
+    findProject = func(testManifest *repo.Manifest, testSourceRepo string) *repo.Project { return &testProject }
+    writeFile = func(string, []byte, os.FileMode) error { return nil }
+
+    os.Exit(m.Run())
+}
+
+func TestRun(t *testing.T) {
+    err := run(testManifestUrl, testSourceRepo)
+    assert.Nil(t, err)
+}
+
+func TestRunNewGitUrlError(t *testing.T) {
+    oldNewGitUrl := newGitUrl
+    defer func() { newGitUrl = oldNewGitUrl }()
+    newGitUrl  = func(testGitUrlStr string) (*git.GitUrl, error) {
+        return nil, fmt.Errorf("Spooky error")
+    }
+
+    err := run(testManifestUrl, testSourceRepo)
+
+    expectedError := fmt.Errorf("Error validating manifest URL: Spooky error\n")
+    assert.Equal(t, err, expectedError)
+}
+
+func TestRunRepoInitError(t *testing.T) {
+    oldRepoInit := repoInit
+    defer func() { repoInit = oldRepoInit }()
+    repoInit = func(checkoutUrl, branch, path string) error {
+        return fmt.Errorf("Spooky error")
+    }
+
+    err := run(testManifestUrl, testSourceRepo)
+
+    expectedError := fmt.Errorf("Error executing 'repo init': Spooky error\n")
+    assert.Equal(t, err, expectedError)
+}
+
+func TestRunParseManifestFileError(t *testing.T) {
+    oldParseManifestFile := parseManifestFile
+    defer func() { parseManifestFile = oldParseManifestFile }()
+    parseManifestFile = func() (*repo.Manifest, error) {
+        return &testManifest, fmt.Errorf("Spooky error")
+    }
+
+    err := run(testManifestUrl, testSourceRepo)
+
+    expectedError := fmt.Errorf("Error parsing manifest file: Spooky error\n")
+    assert.Equal(t, err, expectedError)
+}
+
+func TestRunFindProjectError(t *testing.T) {
+    oldFindProject := findProject
+    defer func() { findProject = oldFindProject }()
+    findProject = func(testManifest *repo.Manifest, testSourceRepo string) *repo.Project {
+        return nil
+    }
+
+    err := run(testManifestUrl, testSourceRepo)
+
+    expectedError := fmt.Errorf("Error: Source repo, %v, is not listed in the manifest file, %v\n", testSourceRepo, testGitUrl.Path)
+    assert.Equal(t, err, expectedError)
+}
+
+func TestRunRepoSyncError(t *testing.T) {
+    oldRepoSync := repoSync
+    defer func() { repoSync = oldRepoSync }()
+    repoSync = func() error { return fmt.Errorf("Spooky error") }
+
+    err := run(testManifestUrl, testSourceRepo)
+
+    expectedError := fmt.Errorf("Error executing 'repo sync': Spooky error\n")
+    assert.Equal(t, err, expectedError)
+}
+
+func TestRunWriteFileError(t *testing.T) {
+    oldWriteFile := writeFile
+    defer func() { writeFile = oldWriteFile }()
+    writeFile = func(string, []byte, os.FileMode) error {
+        return fmt.Errorf("Spooky error")
+    }
+
+    err := run(testManifestUrl, testSourceRepo)
+
+    expectedError := fmt.Errorf("Error writing to %v: Spooky error\n", sourcePathFile)
+    assert.Equal(t, err, expectedError)
+}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -1,0 +1,94 @@
+package repo
+
+import (
+  "encoding/xml"
+  "fmt"
+  "io/ioutil"
+  "os"
+  "os/exec"
+  "strings"
+)
+
+// manifestPath is generated following successful execution of "repo init"
+const manifestPath string = ".repo/manifest.xml"
+
+var (
+    execCommand = exec.Command
+    open = os.Open
+    readAll = ioutil.ReadAll
+    unmarshal = xml.Unmarshal
+)
+
+// A Project represents a <project> XML element
+type Project struct {
+  Path string `xml:"path,attr"`
+  Name string `xml:"name,attr"`
+}
+
+// A Manifest represents a <manifest> XML element
+type Manifest struct {
+  Projects []Project `xml:"project"`
+}
+
+// Init executes the "repo init" command
+func Init(checkoutUrl, branch, path string) error {
+    if path == "" {
+        path = "default.xml"
+    }
+
+    cmd := execCommand("repo", "init", "-u", checkoutUrl, "-b", branch, "-m", path)
+
+    fmt.Printf("repo init -u %v -b %v -m %v\n", checkoutUrl, branch, path)
+    output, err := cmd.CombinedOutput()
+    fmt.Println(string(output[:]))
+
+    return err
+}
+
+// Sync executes the "repo sync" command
+func Sync() error {
+    cmd := execCommand("repo", "sync", "-d", "-c", "--jobs=4")
+
+    fmt.Println("repo sync -d -c --jobs=4")
+    output, err := cmd.CombinedOutput()
+    fmt.Println(string(output[:]))
+
+    return err
+}
+
+// ParseManifestFile parses the manifest file located in manifestPath
+// If valid, a Manifest object is returned
+func ParseManifestFile() (*Manifest, error) {
+    xmlFile, err := open(manifestPath)
+    if err != nil {
+        return nil, err
+    }
+    defer xmlFile.Close()
+
+    content, err := readAll(xmlFile)
+    if err != nil {
+        return nil, err
+    }
+
+    manifest := Manifest {}
+
+    err = unmarshal([]byte(content), &manifest)
+    if err != nil {
+        return nil, err
+    }
+
+    return &manifest, err
+}
+
+// FindProject returns a Project in Manifest whose Name matches sourceRepo
+// If no project is found, nil is returned
+func FindProject(manifest *Manifest, sourceRepo string) *Project {
+    for _, project := range manifest.Projects {
+        projectName := strings.TrimSuffix(project.Name, ".git")
+        sourceRepo = strings.TrimSuffix(sourceRepo, ".git")
+        if projectName == sourceRepo {
+            return &project
+        }
+    }
+    return nil
+}

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -1,0 +1,155 @@
+package repo
+
+import (
+    "fmt"
+    "io"
+    "os"
+    "os/exec"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+var (
+    project1 = Project { Path: "primary", Name: "filbird/v4-repo-test.git" }
+    project2 = Project { Path: "dependencies/timeout", Name: "filbird/v4-timeout-test.git" }
+    project3 = Project { Path: "dependencies/cron", Name: "filbird/v4-cron-test.git" }
+    testManifest = Manifest { Projects: []Project { project1, project2, project3 } }
+);
+
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestMain(m *testing.M) {
+    open = func(f string) (*os.File, error) {
+		return os.Open("../data/manifest.xml")
+	}
+
+    os.Exit(m.Run())
+}
+
+func TestInit(t *testing.T) {
+    execCommand = fakeExecCommand
+    defer func() { execCommand = exec.Command }()
+
+    err := Init("filbird/v4-repo-test.git", "master", "")
+
+    assert.Nil(t, err)
+}
+
+func TestSync(t *testing.T) {
+    execCommand = fakeExecCommand
+    defer func() { execCommand = exec.Command }()
+
+    err := Sync()
+
+    assert.Nil(t, err)
+}
+
+func TestParseManifestFile(t *testing.T) {
+    oldOpen := open
+    defer func() { open = oldOpen }()
+
+    open = func(f string) (*os.File, error) {
+		return os.Open("../data/manifest.xml")
+	}
+
+    manifest, err := ParseManifestFile();
+    if err != nil {
+        t.Errorf("ParseManifestFile() error = %q, should be nil", err)
+    }
+
+    assert.Equal(t, *manifest, testManifest)
+}
+
+func TestParseManifestFileOpenError(t *testing.T) {
+    oldOpen := open
+    defer func() { open = oldOpen }()
+    open = func(f string) (*os.File, error) {
+		return nil, fmt.Errorf("Spooky error")
+	}
+
+    manifest, err := ParseManifestFile();
+
+    assert.Nil(t, manifest)
+    assert.Equal(t, err, fmt.Errorf("Spooky error"))
+}
+
+func TestParseManifestFileReadAllError(t *testing.T) {
+    oldReadAll := readAll
+    defer func() { readAll = oldReadAll }()
+    readAll = func(r io.Reader) ([]byte, error) {
+		return []byte{}, fmt.Errorf("Spooky error")
+	}
+
+    manifest, err := ParseManifestFile();
+
+    assert.Nil(t, manifest)
+    assert.Equal(t, err, fmt.Errorf("Spooky error"))
+}
+
+func TestParseManifestUnmarshlError(t *testing.T) {
+    oldUnmarshal := unmarshal
+    defer func() { unmarshal = oldUnmarshal }()
+    unmarshal = func(data []byte, v interface{}) error {
+		return fmt.Errorf("Spooky error")
+	}
+
+    manifest, err := ParseManifestFile();
+
+    assert.Nil(t, manifest)
+    assert.Equal(t, err, fmt.Errorf("Spooky error"))
+}
+
+func TestFindProject(t *testing.T) {
+    sourceRepo := "filbird/v4-repo-test"
+    project := FindProject(&testManifest, sourceRepo);
+
+    assert.Equal(t, *project, project1)
+}
+
+func TestFindProjectDoesNotExist(t *testing.T) {
+    sourceRepo := "fake"
+    project := FindProject(&testManifest, sourceRepo);
+
+    assert.Nil(t, project)
+}
+
+// This is a fake test for mocking out exec calls.
+// See https://golang.org/src/os/exec/exec_test.go and
+// https://npf.io/2015/06/testing-exec-command/ for more info
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	args := os.Args[:]
+	for i, val := range os.Args { // Should become something lke ["repo", "init"]
+		args = os.Args[i:]
+		if val == "--" {
+			args = args[1:]
+			break
+		}
+	}
+
+	if len(args) >= 2 && args[0] == "repo" {
+		switch args[1] {
+		default:
+			os.Exit(255)
+		case "init":
+            fmt.Println("Initializing repo manifest directory")
+            return
+		case "sync":
+            fmt.Println("Syncing repo dependencies")
+			return
+		}
+	}
+
+	os.Exit(255)
+}


### PR DESCRIPTION
This PR adds the repo package for handling manifest file parsing as well as command execution (e.g. `repo init` and `repo sync`)

Since we cannot directly export environment variables to the parent process, this module will write the source path to a file, `sourcePath`, which will then be exported by (`_getCheckoutCommand`)[https://github.com/screwdriver-cd/scm-github/blob/master/index.js#L272].

For further context:
https://github.com/screwdriver-cd/screwdriver/issues/1041