### PR TITLE
fix(1041): Enable HTTPS checkout for repo manifest

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -23,7 +23,7 @@ func (git *GitUrl) GetCloneInfo() (url, branch string) {
 func New(gitUrlStr string) (*GitUrl, error) {
 	// This would match something like git@github.com:org/repo.git/path#branch
 	// path and branch are optional. If not given, default values are "" and "master"
-	gitUrlRegex, _ := regexp.Compile("^git@([^/:#]+):([^/:#]+)/+([^/:#]+)\\.git(/[^#]*)?(#.+)?")
+	gitUrlRegex, _ := regexp.Compile("^(?:git@|https://)([^/:#]+)(?::|/)([^/:#]+)/+([^/:#]+)\\.git(/[^#]*)?(#.+)?")
 	parseResult := gitUrlRegex.FindStringSubmatch(gitUrlStr)
 
 	if parseResult == nil {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -6,28 +6,35 @@ import (
 )
 
 func TestParseGitUrlSuccess(t *testing.T) {
-	var gitUrl, _ = New("git@github.com:screwdriver-cd/sd-repo.git/model/giturl_test.go#test")
+	gitUrl, _ := New("git@github.com:screwdriver-cd/sd-repo.git/model/giturl_test.go#test")
 	assert.Equal(t, "github.com", gitUrl.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrl.Org)
 	assert.Equal(t, "sd-repo", gitUrl.Repo)
 	assert.Equal(t, "model/giturl_test.go", gitUrl.Path)
 	assert.Equal(t, "test", gitUrl.Branch)
 
-	var gitUrlNoPathNoBranch, _ = New("git@github.com:screwdriver-cd/sd-repo.git")
+	gitUrlNoPathNoBranch, _ := New("git@github.com:screwdriver-cd/sd-repo.git")
 	assert.Equal(t, "github.com", gitUrlNoPathNoBranch.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlNoPathNoBranch.Org)
 	assert.Equal(t, "sd-repo", gitUrlNoPathNoBranch.Repo)
 	assert.Equal(t, "", gitUrlNoPathNoBranch.Path)
 	assert.Equal(t, "master", gitUrlNoPathNoBranch.Branch)
 
-	var gitUrlWeirdBranch, _ = New("git@gitgit.com:screwdriver-cd/sd-repo.git##test")
+	gitUrlHttps, _ := New("https://github.com/screwdriver-cd/sd-repo.git")
+	assert.Equal(t, "github.com", gitUrlHttps.Host)
+	assert.Equal(t, "screwdriver-cd", gitUrlNoPathNoBranch.Org)
+	assert.Equal(t, "sd-repo", gitUrlHttps.Repo)
+	assert.Equal(t, "", gitUrlHttps.Path)
+	assert.Equal(t, "master", gitUrlHttps.Branch)
+
+	gitUrlWeirdBranch, _ := New("git@gitgit.com:screwdriver-cd/sd-repo.git##test")
 	assert.Equal(t, "gitgit.com", gitUrlWeirdBranch.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlWeirdBranch.Org)
 	assert.Equal(t, "sd-repo", gitUrlWeirdBranch.Repo)
 	assert.Equal(t, "", gitUrlWeirdBranch.Path)
 	assert.Equal(t, "#test", gitUrlWeirdBranch.Branch)
 
-	var gitUrlWeirdPath, _ = New("git@github.com:screwdriver-cd//sd-repo.git//a/bb/c.xml")
+	gitUrlWeirdPath, _ := New("git@github.com:screwdriver-cd//sd-repo.git//a/bb/c.xml")
 	assert.Equal(t, "github.com", gitUrlWeirdPath.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlWeirdPath.Org)
 	assert.Equal(t, "sd-repo", gitUrlWeirdPath.Repo)
@@ -36,25 +43,25 @@ func TestParseGitUrlSuccess(t *testing.T) {
 }
 
 func TestParseGitUrlError(t *testing.T) {
-	var gitUrlBad1, err1 = New("git@github.com::screwdriver-cd/sd-repo.git/model/giturl_test.go#test")
+	gitUrlBad1, err1 := New("git@github.com::screwdriver-cd/sd-repo.git/model/giturl_test.go#test")
 	assert.Nil(t, gitUrlBad1)
 	if assert.Error(t, err1, "should return error on invalid git config") {
 		assert.Equal(t, "Not a valid git url git@github.com::screwdriver-cd/sd-repo.git/model/giturl_test.go#test", err1.Error())
 	}
 
-	var gitUrlBad2, err2 = New("git@github.com:sd-repo.git/model/giturl_test.go#test")
+	gitUrlBad2, err2 := New("git@github.com:sd-repo.git/model/giturl_test.go#test")
 	assert.Nil(t, gitUrlBad2)
 	if assert.Error(t, err2, "should return error on invalid git config") {
 		assert.Equal(t, "Not a valid git url git@github.com:sd-repo.git/model/giturl_test.go#test", err2.Error())
 	}
 
-	var gitUrlBad3, err3 = New("git@github.com:a/b/model/giturl_test.git")
+	gitUrlBad3, err3 := New("git@github.com:a/b/model/giturl_test.git")
 	assert.Nil(t, gitUrlBad3)
 	if assert.Error(t, err3, "should return error on invalid git config") {
 		assert.Equal(t, "Not a valid git url git@github.com:a/b/model/giturl_test.git", err3.Error())
 	}
 
-	var gitUrlBad4, err4 = New("github.com:a/b.git#branch")
+	gitUrlBad4, err4 := New("github.com:a/b.git#branch")
 	assert.Nil(t, gitUrlBad4)
 	if assert.Error(t, err4, "should return error on invalid git config") {
 		assert.Equal(t, "Not a valid git url github.com:a/b.git#branch", err4.Error())
@@ -62,15 +69,15 @@ func TestParseGitUrlError(t *testing.T) {
 }
 
 func TestGetCloneInfo(t *testing.T) {
-	var gitUrl1, err1 = New("git@gitgit.com:screwdriver-cd/sd-repo.git##test")
+	gitUrl1, err1 := New("git@gitgit.com:screwdriver-cd/sd-repo.git##test")
 	assert.Nil(t, err1)
-	var gitCloneUrl1, branch1 = gitUrl1.GetCloneInfo()
+	gitCloneUrl1, branch1 := gitUrl1.GetCloneInfo()
 	assert.Equal(t, "git@gitgit.com:screwdriver-cd/sd-repo.git", gitCloneUrl1)
 	assert.Equal(t, "#test", branch1)
 
-	var gitUrl2, err2 = New("git@gitgit.com:screwdriver-cd/sd-repo2.git/blah/blhablha")
+	gitUrl2, err2 := New("git@gitgit.com:screwdriver-cd/sd-repo2.git/blah/blhablha")
 	assert.Nil(t, err2)
-	var gitCloneUrl2, branch2 = gitUrl2.GetCloneInfo()
+	gitCloneUrl2, branch2 := gitUrl2.GetCloneInfo()
 	assert.Equal(t, "git@gitgit.com:screwdriver-cd/sd-repo2.git", gitCloneUrl2)
 	assert.Equal(t, "master", branch2)
 }


### PR DESCRIPTION
Relaxing the constraint on the repo manifest checkout URL to include HTTPS.

https://github.com/screwdriver-cd/screwdriver/issues/1041