### PR TITLE
fix(1041): Add 'Protocol' field to GitUrl struct

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -7,15 +7,20 @@ import (
 )
 
 type GitUrl struct {
-	Host   string
-	Org    string
-	Repo   string
-	Path   string
-	Branch string
+	Protocol string
+	Host     string
+	Org      string
+	Repo     string
+	Path     string
+	Branch   string
 }
 
 // GetCloneInfo returns the url and branch of the GitUrl
 func (git *GitUrl) GetCloneInfo() (url, branch string) {
+	if git.Protocol == "https" {
+		return fmt.Sprintf("https://%+s/%+s/%+s.git", git.Host, git.Org, git.Repo), git.Branch
+	}
+	
 	return fmt.Sprintf("git@%+s:%+s/%+s.git", git.Host, git.Org, git.Repo), git.Branch
 }
 
@@ -23,19 +28,20 @@ func (git *GitUrl) GetCloneInfo() (url, branch string) {
 func New(gitUrlStr string) (*GitUrl, error) {
 	// This would match something like git@github.com:org/repo.git/path#branch
 	// path and branch are optional. If not given, default values are "" and "master"
-	gitUrlRegex, _ := regexp.Compile("^(?:git@|https://)([^/:#]+)(?::|/)([^/:#]+)/+([^/:#]+)\\.git(/[^#]*)?(#.+)?")
+	gitUrlRegex, _ := regexp.Compile("^(git|https)(?:@|://)([^/:#]+)(?::|/)([^/:#]+)/+([^/:#]+)\\.git(/[^#]*)?(#.+)?")
 	parseResult := gitUrlRegex.FindStringSubmatch(gitUrlStr)
 
 	if parseResult == nil {
 		return nil, fmt.Errorf("Not a valid git url %+s", gitUrlStr)
 	}
 
-	gitUrl := GitUrl{
-		Host:   parseResult[1],
-		Org:    parseResult[2],
-		Repo:   parseResult[3],
-		Path:   parseResult[4],
-		Branch: parseResult[5],
+	gitUrl := GitUrl {
+		Protocol: parseResult[1],
+		Host:     parseResult[2],
+		Org:      parseResult[3],
+		Repo:     parseResult[4],
+		Path:     parseResult[5],
+		Branch:   parseResult[6],
 	}
 
 	if gitUrl.Branch == "" {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestParseGitUrlSuccess(t *testing.T) {
 	gitUrl, _ := New("git@github.com:screwdriver-cd/sd-repo.git/model/giturl_test.go#test")
+	assert.Equal(t, "git", gitUrl.Protocol)
 	assert.Equal(t, "github.com", gitUrl.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrl.Org)
 	assert.Equal(t, "sd-repo", gitUrl.Repo)
@@ -14,6 +15,7 @@ func TestParseGitUrlSuccess(t *testing.T) {
 	assert.Equal(t, "test", gitUrl.Branch)
 
 	gitUrlNoPathNoBranch, _ := New("git@github.com:screwdriver-cd/sd-repo.git")
+	assert.Equal(t, "git", gitUrlNoPathNoBranch.Protocol)
 	assert.Equal(t, "github.com", gitUrlNoPathNoBranch.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlNoPathNoBranch.Org)
 	assert.Equal(t, "sd-repo", gitUrlNoPathNoBranch.Repo)
@@ -21,6 +23,7 @@ func TestParseGitUrlSuccess(t *testing.T) {
 	assert.Equal(t, "master", gitUrlNoPathNoBranch.Branch)
 
 	gitUrlHttps, _ := New("https://github.com/screwdriver-cd/sd-repo.git")
+	assert.Equal(t, "https", gitUrlHttps.Protocol)
 	assert.Equal(t, "github.com", gitUrlHttps.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlNoPathNoBranch.Org)
 	assert.Equal(t, "sd-repo", gitUrlHttps.Repo)
@@ -28,6 +31,7 @@ func TestParseGitUrlSuccess(t *testing.T) {
 	assert.Equal(t, "master", gitUrlHttps.Branch)
 
 	gitUrlWeirdBranch, _ := New("git@gitgit.com:screwdriver-cd/sd-repo.git##test")
+	assert.Equal(t, "git", gitUrlWeirdBranch.Protocol)
 	assert.Equal(t, "gitgit.com", gitUrlWeirdBranch.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlWeirdBranch.Org)
 	assert.Equal(t, "sd-repo", gitUrlWeirdBranch.Repo)
@@ -35,6 +39,7 @@ func TestParseGitUrlSuccess(t *testing.T) {
 	assert.Equal(t, "#test", gitUrlWeirdBranch.Branch)
 
 	gitUrlWeirdPath, _ := New("git@github.com:screwdriver-cd//sd-repo.git//a/bb/c.xml")
+	assert.Equal(t, "git", gitUrlWeirdBranch.Protocol)
 	assert.Equal(t, "github.com", gitUrlWeirdPath.Host)
 	assert.Equal(t, "screwdriver-cd", gitUrlWeirdPath.Org)
 	assert.Equal(t, "sd-repo", gitUrlWeirdPath.Repo)
@@ -80,4 +85,10 @@ func TestGetCloneInfo(t *testing.T) {
 	gitCloneUrl2, branch2 := gitUrl2.GetCloneInfo()
 	assert.Equal(t, "git@gitgit.com:screwdriver-cd/sd-repo2.git", gitCloneUrl2)
 	assert.Equal(t, "master", branch2)
+
+	gitUrlHttps, err3 := New("https://github.com/screwdriver-cd/sd-repo.git/manifest.xml")
+	assert.Nil(t, err3)
+	gitCloneHttps, branch3 := gitUrlHttps.GetCloneInfo()
+	assert.Equal(t, "https://github.com/screwdriver-cd/sd-repo.git", gitCloneHttps)
+	assert.Equal(t, "master", branch3)
 }


### PR DESCRIPTION
Including a `Protocol` field in the GitUrl struct. This allows us to construct a checkout URL that corresponds to the initial protocol (e.g. ssh and https).

https://github.com/screwdriver-cd/screwdriver/issues/1041

