### PR TITLE
fix: change manifest path for git-repo 2.4 compatiblity

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,20 @@
 builds:
   - binary: sd-repo
+    # Build for Linux and OSX
     goos:
       - linux
       - darwin
     goarch:
       - amd64
+    # Include the default settings from https://goreleaser.com/#builds
+    # Also include static compilation
+    # ldflags: -d -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -extldflags "-static"
+    # Ensure the binary is static
+    env:
+      - CGO_ENABLED=0
+archives:
+  - format: binary
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
-archive:
-  format: binary
-  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+# Put the packages in the artifacts dir (but it won't eval environment variables)
+dist: /sd/workspace/artifacts/dist

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import(
 
 // sourcePathFile is the file in which the checked out source path
 // will be written to
-const sourcePathFile = "sourcePath"
+const sourcePathFile string= "sourcePath"
 
 var (
     newGitUrl = git.New

--- a/main_test.go
+++ b/main_test.go
@@ -11,8 +11,8 @@ import(
 )
 
 const (
-    testManifestUrl = "git@github.com:filbird/v4-repo-test.git/default.xml"
-    testSourceRepo = "filbird/v4-repo-test.git"
+    testManifestUrl string= "git@github.com:filbird/v4-repo-test.git/default.xml"
+    testSourceRepo string= "filbird/v4-repo-test.git"
 )
 
 var (

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -55,6 +55,9 @@ func TestParseManifestFile(t *testing.T) {
     oldOpen := open
     defer func() { open = oldOpen }()
 
+    execCommand = fakeExecCommand
+    defer func() { execCommand = exec.Command }()
+
     open = func(f string) (*os.File, error) {
 		return os.Open("../data/manifest.xml")
 	}
@@ -70,6 +73,10 @@ func TestParseManifestFile(t *testing.T) {
 func TestParseManifestFileOpenError(t *testing.T) {
     oldOpen := open
     defer func() { open = oldOpen }()
+
+    execCommand = fakeExecCommand
+    defer func() { execCommand = exec.Command }()
+
     open = func(f string) (*os.File, error) {
 		return nil, fmt.Errorf("Spooky error")
 	}
@@ -83,6 +90,10 @@ func TestParseManifestFileOpenError(t *testing.T) {
 func TestParseManifestFileReadAllError(t *testing.T) {
     oldReadAll := readAll
     defer func() { readAll = oldReadAll }()
+
+    execCommand = fakeExecCommand
+    defer func() { execCommand = exec.Command }()
+
     readAll = func(r io.Reader) ([]byte, error) {
 		return []byte{}, fmt.Errorf("Spooky error")
 	}
@@ -96,6 +107,10 @@ func TestParseManifestFileReadAllError(t *testing.T) {
 func TestParseManifestUnmarshlError(t *testing.T) {
     oldUnmarshal := unmarshal
     defer func() { unmarshal = oldUnmarshal }()
+
+    execCommand = fakeExecCommand
+    defer func() { execCommand = exec.Command }()
+
     unmarshal = func(data []byte, v interface{}) error {
 		return fmt.Errorf("Spooky error")
 	}
@@ -141,7 +156,10 @@ func TestHelperProcess(t *testing.T) {
 	if len(args) >= 2 && args[0] == "repo" {
 		switch args[1] {
 		default:
-			os.Exit(255)
+            os.Exit(255)
+        case "version":
+            fmt.Println("repo version v2.4.334")
+            return
 		case "init":
             fmt.Println("Initializing repo manifest directory")
             return


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
currently sd-repo does not work with git-repo 2.4 and above because git-repo changed manifest path, and user have to pin git-repo to version 2.3
 
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
fix manifest path so it would work with git-repo 2.4

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
